### PR TITLE
Simplified Loose Ends

### DIFF
--- a/examples/data/bl/sounds-tests/C1685_98_simpler_1.json
+++ b/examples/data/bl/sounds-tests/C1685_98_simpler_1.json
@@ -1,0 +1,656 @@
+{
+    "@context": "http://iiif.io/api/presentation/3/context.json",
+    "id": "https://iiif-commons.github.io/iiif-av-component/examples/data/bl/sounds-tests/C1685_98.json",
+    "label": {  "en": [ "C1685/98 Loose ends 17/7/99"  ] },
+
+    "metadata": [
+        {
+            "label": { "en": [ "Title" ] },
+            "value": { "en": [ "Loose ends 17/7/99" ] }
+        }
+    ],
+    "sequences": [
+        {
+            "canvases": [
+                {
+                    "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100052359795.0x000004",
+                    "type": "Canvas",
+                    "label": { "en": [ "Tape 1 Side 1" ] },
+                    "duration": 4119.16,
+                    "content": [
+                        {
+                            "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100052359795.0x000004/anno",
+                            "type": "AnnotationPage",
+                            "items": [
+                                {
+                                    "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100052359795.0x000004/anno/",
+                                    "type": "Annotation",
+                                    "motivation": "painting",
+                                    "target": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100052359795.0x000004",
+                                    "timeMode": "trim",
+                                    "body": [
+                                        {
+                                            "items": [
+                                                {
+                                                    "format": "audio/mp4",
+                                                    "id": "http://resources.digirati.com/bl/C1685_98/vdc_100052359795.0x000019.mp4",
+                                                    "type": "Audio"
+                                                }
+                                            ],
+                                            "type": "Choice"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100052359795.0x000005",
+                    "type": "Canvas",
+                    "label": "Tape 1 Side 2",
+                    "duration": 3723.4,
+                    "content": [
+                        {
+                            "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100052359795.0x000005/anno",
+                            "items": [
+                                {
+                                    "body": [
+                                        {
+                                            "items": [
+                                                {
+                                                    "format": "audio/mp4",
+                                                    "id": "http://resources.digirati.com/bl/C1685_98/vdc_100052359795.0x00001b.mp4",
+                                                    "type": "Audio"
+                                                }
+                                            ],
+                                            "type": "Choice"
+                                        }
+                                    ],
+                                    "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100052359795.0x000005/anno/",
+                                    "motivation": "painting",
+                                    "target": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100052359795.0x000005",
+                                    "timeMode": "trim",
+                                    "type": "Annotation"
+                                }
+                            ],
+                            "type": "AnnotationPage"
+                        }
+                    ]
+                }
+            ],
+            "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100052359795.0x000001",
+            "type": "Sequence"
+        }
+    ],
+    "structures": [
+        {
+            "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100052359795.0x000002/top",
+            "label": {
+                "en": [
+                    "Loose ends 17/7/99"
+                ]
+            },
+            "members": [
+                {
+                    "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100052359795.0x000004",
+                    "type": "Canvas"
+                },
+                {
+                    "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100052359795.0x000005",
+                    "type": "Canvas"
+                },
+                {
+                    "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100052359795.0x000006",
+                    "label": {
+                        "en": [
+                            "Loose ends"
+                        ]
+                    },
+                    "members": [
+                        {
+                            "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100052359795.0x000004#t=0,2504.64",
+                            "type": "Canvas"
+                        },
+                        {
+                            "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100052359795.0x000007",
+                            "label": {
+                                "en": [
+                                    "There's a touch"
+                                ]
+                            },
+                            "members": [
+                                {
+                                    "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100052359795.0x000004#t=560,741.28",
+                                    "type": "Canvas"
+                                }
+                            ],
+                            "metadata": [
+                                {
+                                    "label": {
+                                        "en": [
+                                            "Identifier"
+                                        ]
+                                    },
+                                    "value": {
+                                        "en": [
+                                            "C1685/98"
+                                        ]
+                                    }
+                                },
+                                {
+                                    "label": {
+                                        "en": [
+                                            "Title"
+                                        ]
+                                    },
+                                    "value": {
+                                        "en": [
+                                            "There's a touch"
+                                        ]
+                                    }
+                                },
+                                {
+                                    "label": {
+                                        "en": [
+                                            "Contributor"
+                                        ]
+                                    },
+                                    "value": {
+                                        "en": [
+                                            "The Proclaimers"
+                                        ]
+                                    }
+                                },
+                                {
+                                    "label": {
+                                        "en": [
+                                            "Date"
+                                        ]
+                                    },
+                                    "value": {
+                                        "en": [
+                                            "not after 1999-07-17"
+                                        ]
+                                    }
+                                }
+                            ],
+                            "type": "Range"
+                        },
+                        {
+                            "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100052359795.0x000008",
+                            "label": {
+                                "en": [
+                                    "Song of dreams"
+                                ]
+                            },
+                            "members": [
+                                {
+                                    "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100052359795.0x000004#t=1700.36,1914.84",
+                                    "type": "Canvas"
+                                }
+                            ],
+                            "metadata": [
+                                {
+                                    "label": {
+                                        "en": [
+                                            "Identifier"
+                                        ]
+                                    },
+                                    "value": {
+                                        "en": [
+                                            "C1685/98"
+                                        ]
+                                    }
+                                },
+                                {
+                                    "label": {
+                                        "en": [
+                                            "Title"
+                                        ]
+                                    },
+                                    "value": {
+                                        "en": [
+                                            "Song of dreams"
+                                        ]
+                                    }
+                                },
+                                {
+                                    "label": {
+                                        "en": [
+                                            "Contributor"
+                                        ]
+                                    },
+                                    "value": {
+                                        "en": [
+                                            "Taylor, Becky (singer, female)",
+                                            "unidentified orchestra"
+                                        ]
+                                    }
+                                },
+                                {
+                                    "label": {
+                                        "en": [
+                                            "Date"
+                                        ]
+                                    },
+                                    "value": {
+                                        "en": [
+                                            "not after 1999-07-17"
+                                        ]
+                                    }
+                                }
+                            ],
+                            "type": "Range"
+                        }
+                    ],
+                    "metadata": [
+                        {
+                            "label": {
+                                "en": [
+                                    "Identifier"
+                                ]
+                            },
+                            "value": {
+                                "en": [
+                                    "C1685/98"
+                                ]
+                            }
+                        },
+                        {
+                            "label": {
+                                "en": [
+                                    "Title"
+                                ]
+                            },
+                            "value": {
+                                "en": [
+                                    "Loose ends"
+                                ]
+                            }
+                        },
+                        {
+                            "label": {
+                                "en": [
+                                    "Place"
+                                ]
+                            },
+                            "value": {
+                                "en": [
+                                    "Royal Albert Hall, London"
+                                ]
+                            }
+                        },
+                        {
+                            "label": {
+                                "en": [
+                                    "Contributor"
+                                ]
+                            },
+                            "value": {
+                                "en": [
+                                    "Sherrin, Ned, 1931-2007 (speaker, male; presenter / interviewer)",
+                                    "Glover, Julian, 1935- (speaker, male; interviewee)",
+                                    "Windsor, Barbara, 1937- (speaker, female; interviewee)",
+                                    "The Proclaimers (speakers, male; interviewees / performers)",
+                                    "Frisby, Dominic (speaker, male)",
+                                    "Jupitus, Phil (speaker, male / interviewee)",
+                                    "Taylor, Becky (speaker, female; interviewee / singer)",
+                                    "Brown, Errol (speaker, male; interviewee)"
+                                ]
+                            }
+                        },
+                        {
+                            "label": {
+                                "en": [
+                                    "Date"
+                                ]
+                            },
+                            "value": {
+                                "en": [
+                                    "not after 1999-07-17"
+                                ]
+                            }
+                        }
+                    ],
+                    "type": "Range"
+                },
+                {
+                    "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100052359795.0x00000c",
+                    "label": {
+                        "en": [
+                            "[News May 2001]"
+                        ]
+                    },
+                    "members": [
+                        {
+                            "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100052359795.0x000004#t=2504.64,2661.56",
+                            "type": "Canvas"
+                        }
+                    ],
+                    "metadata": [
+                        {
+                            "label": {
+                                "en": [
+                                    "Identifier"
+                                ]
+                            },
+                            "value": {
+                                "en": [
+                                    "C1685/98"
+                                ]
+                            }
+                        },
+                        {
+                            "label": {
+                                "en": [
+                                    "Title"
+                                ]
+                            },
+                            "value": {
+                                "en": [
+                                    "[News May 2001]"
+                                ]
+                            }
+                        },
+                        {
+                            "label": {
+                                "en": [
+                                    "Contributor"
+                                ]
+                            },
+                            "value": {
+                                "en": [
+                                    "unidentified speaker, female (newsreader)"
+                                ]
+                            }
+                        },
+                        {
+                            "label": {
+                                "en": [
+                                    "Date"
+                                ]
+                            },
+                            "value": {
+                                "en": [
+                                    "not after 2001-05-19"
+                                ]
+                            }
+                        }
+                    ],
+                    "type": "Range"
+                },
+                {
+                    "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100052359795.0x00000e",
+                    "label": {
+                        "en": [
+                            "Saturday review"
+                        ]
+                    },
+                    "members": [
+                        {
+                            "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100052359795.0x000004#t=2661.56,3723.4",
+                            "type": "Canvas"
+                        },
+                        {
+                            "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100052359795.0x000005#t=0,1585.16",
+                            "type": "Canvas"
+                        }
+                    ],
+                    "metadata": [
+                        {
+                            "label": {
+                                "en": [
+                                    "Identifier"
+                                ]
+                            },
+                            "value": {
+                                "en": [
+                                    "C1685/98"
+                                ]
+                            }
+                        },
+                        {
+                            "label": {
+                                "en": [
+                                    "Title"
+                                ]
+                            },
+                            "value": {
+                                "en": [
+                                    "Saturday review"
+                                ]
+                            }
+                        },
+                        {
+                            "label": {
+                                "en": [
+                                    "Contributor"
+                                ]
+                            },
+                            "value": {
+                                "en": [
+                                    "Sutcliffe, Thomas, 1956- (speaker, male; presenter)",
+                                    "Roberts, Michèle, 1949- (speaker, female)",
+                                    "White, Jim, speaker (speaker, male)",
+                                    "Whittam Smith, Andreas, 1937- (speaker, male)"
+                                ]
+                            }
+                        },
+                        {
+                            "label": {
+                                "en": [
+                                    "Date"
+                                ]
+                            },
+                            "value": {
+                                "en": [
+                                    "not after 2001-05-19"
+                                ]
+                            }
+                        }
+                    ],
+                    "type": "Range"
+                },
+                {
+                    "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100052359795.0x000011",
+                    "label": {
+                        "en": [
+                            "My dear Jim - Letters to a friend [2]"
+                        ]
+                    },
+                    "members": [
+                        {
+                            "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100052359795.0x000005#t=1585.16,2501.8",
+                            "type": "Canvas"
+                        }
+                    ],
+                    "metadata": [
+                        {
+                            "label": {
+                                "en": [
+                                    "Identifier"
+                                ]
+                            },
+                            "value": {
+                                "en": [
+                                    "C1685/98"
+                                ]
+                            }
+                        },
+                        {
+                            "label": {
+                                "en": [
+                                    "Title"
+                                ]
+                            },
+                            "value": {
+                                "en": [
+                                    "My dear Jim - Letters to a friend [2]"
+                                ]
+                            }
+                        },
+                        {
+                            "label": {
+                                "en": [
+                                    "Contributor"
+                                ]
+                            },
+                            "value": {
+                                "en": [
+                                    "Rietti, Robert, 1923-2015 (speaker, male)"
+                                ]
+                            }
+                        },
+                        {
+                            "label": {
+                                "en": [
+                                    "Date"
+                                ]
+                            },
+                            "value": {
+                                "en": [
+                                    "not after 2001-05-19"
+                                ]
+                            }
+                        }
+                    ],
+                    "type": "Range"
+                },
+                {
+                    "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100052359795.0x000013",
+                    "label": {
+                        "en": [
+                            "[News May 2001]"
+                        ]
+                    },
+                    "members": [
+                        {
+                            "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100052359795.0x000005#t=2501.8,2620.44",
+                            "type": "Canvas"
+                        }
+                    ],
+                    "metadata": [
+                        {
+                            "label": {
+                                "en": [
+                                    "Identifier"
+                                ]
+                            },
+                            "value": {
+                                "en": [
+                                    "C1685/98"
+                                ]
+                            }
+                        },
+                        {
+                            "label": {
+                                "en": [
+                                    "Title"
+                                ]
+                            },
+                            "value": {
+                                "en": [
+                                    "[News May 2001]"
+                                ]
+                            }
+                        },
+                        {
+                            "label": {
+                                "en": [
+                                    "Contributor"
+                                ]
+                            },
+                            "value": {
+                                "en": [
+                                    "unidentified speaker, female (newsreader)"
+                                ]
+                            }
+                        },
+                        {
+                            "label": {
+                                "en": [
+                                    "Date"
+                                ]
+                            },
+                            "value": {
+                                "en": [
+                                    "not after 1999-05-19"
+                                ]
+                            }
+                        }
+                    ],
+                    "type": "Range"
+                },
+                {
+                    "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100052359795.0x000015",
+                    "label": {
+                        "en": [
+                            "The archive hour: Humph at 80"
+                        ]
+                    },
+                    "members": [
+                        {
+                            "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100052359795.0x000005#t=2620.44,3723.4",
+                            "type": "Canvas"
+                        }
+                    ],
+                    "metadata": [
+                        {
+                            "label": {
+                                "en": [
+                                    "Identifier"
+                                ]
+                            },
+                            "value": {
+                                "en": [
+                                    "C1685/98"
+                                ]
+                            }
+                        },
+                        {
+                            "label": {
+                                "en": [
+                                    "Title"
+                                ]
+                            },
+                            "value": {
+                                "en": [
+                                    "The archive hour: Humph at 80"
+                                ]
+                            }
+                        },
+                        {
+                            "label": {
+                                "en": [
+                                    "Contributor"
+                                ]
+                            },
+                            "value": {
+                                "en": [
+                                    "Lyttelton, Humphrey, 1921-2008 (speaker, male; presenter)",
+                                    "unidentified speakers"
+                                ]
+                            }
+                        },
+                        {
+                            "label": {
+                                "en": [
+                                    "Date"
+                                ]
+                            },
+                            "value": {
+                                "en": [
+                                    "not after 2001-05-19"
+                                ]
+                            }
+                        }
+                    ],
+                    "type": "Range"
+                }
+            ],
+            "type": "Range"
+        }
+    ],
+    "type": "Manifest"
+}

--- a/examples/data/bl/sounds-tests/C1685_98_simpler_1.json
+++ b/examples/data/bl/sounds-tests/C1685_98_simpler_1.json
@@ -1,8 +1,8 @@
 {
     "@context": "http://iiif.io/api/presentation/3/context.json",
     "id": "https://iiif-commons.github.io/iiif-av-component/examples/data/bl/sounds-tests/C1685_98.json",
+    "type": "Manifest",
     "label": {  "en": [ "C1685/98 Loose ends 17/7/99"  ] },
-
     "metadata": [
         {
             "label": { "en": [ "Title" ] },
@@ -11,6 +11,8 @@
     ],
     "sequences": [
         {
+            "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100052359795.0x000001",
+            "type": "Sequence",
             "canvases": [
                 {
                     "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100052359795.0x000004",
@@ -55,6 +57,11 @@
                             "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100052359795.0x000005/anno",
                             "items": [
                                 {
+                                    "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100052359795.0x000005/anno/",
+                                    "type": "Annotation",
+                                    "motivation": "painting",
+                                    "target": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100052359795.0x000005",
+                                    "timeMode": "trim",
                                     "body": [
                                         {
                                             "items": [
@@ -66,31 +73,21 @@
                                             ],
                                             "type": "Choice"
                                         }
-                                    ],
-                                    "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100052359795.0x000005/anno/",
-                                    "motivation": "painting",
-                                    "target": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100052359795.0x000005",
-                                    "timeMode": "trim",
-                                    "type": "Annotation"
+                                    ]
                                 }
                             ],
                             "type": "AnnotationPage"
                         }
                     ]
                 }
-            ],
-            "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100052359795.0x000001",
-            "type": "Sequence"
+            ]
         }
     ],
     "structures": [
         {
             "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100052359795.0x000002/top",
-            "label": {
-                "en": [
-                    "Loose ends 17/7/99"
-                ]
-            },
+            "type": "Range",
+            "label": { "en": [ "Loose ends 17/7/99" ] },
             "members": [
                 {
                     "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100052359795.0x000004",
@@ -102,11 +99,8 @@
                 },
                 {
                     "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100052359795.0x000006",
-                    "label": {
-                        "en": [
-                            "Loose ends"
-                        ]
-                    },
+                    "type": "Range",
+                    "label": { "en": [ "Loose ends" ] },
                     "members": [
                         {
                             "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100052359795.0x000004#t=0,2504.64",
@@ -114,279 +108,43 @@
                         },
                         {
                             "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100052359795.0x000007",
-                            "label": {
-                                "en": [
-                                    "There's a touch"
-                                ]
-                            },
+                            "type": "Range",
+                            "label": { "en": [ "There's a touch" ] },
                             "members": [
                                 {
                                     "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100052359795.0x000004#t=560,741.28",
                                     "type": "Canvas"
                                 }
-                            ],
-                            "metadata": [
-                                {
-                                    "label": {
-                                        "en": [
-                                            "Identifier"
-                                        ]
-                                    },
-                                    "value": {
-                                        "en": [
-                                            "C1685/98"
-                                        ]
-                                    }
-                                },
-                                {
-                                    "label": {
-                                        "en": [
-                                            "Title"
-                                        ]
-                                    },
-                                    "value": {
-                                        "en": [
-                                            "There's a touch"
-                                        ]
-                                    }
-                                },
-                                {
-                                    "label": {
-                                        "en": [
-                                            "Contributor"
-                                        ]
-                                    },
-                                    "value": {
-                                        "en": [
-                                            "The Proclaimers"
-                                        ]
-                                    }
-                                },
-                                {
-                                    "label": {
-                                        "en": [
-                                            "Date"
-                                        ]
-                                    },
-                                    "value": {
-                                        "en": [
-                                            "not after 1999-07-17"
-                                        ]
-                                    }
-                                }
-                            ],
-                            "type": "Range"
+                            ]
                         },
                         {
                             "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100052359795.0x000008",
-                            "label": {
-                                "en": [
-                                    "Song of dreams"
-                                ]
-                            },
+                            "type": "Range",
+                            "label": { "en": [ "Song of dreams" ] },
                             "members": [
                                 {
                                     "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100052359795.0x000004#t=1700.36,1914.84",
                                     "type": "Canvas"
                                 }
-                            ],
-                            "metadata": [
-                                {
-                                    "label": {
-                                        "en": [
-                                            "Identifier"
-                                        ]
-                                    },
-                                    "value": {
-                                        "en": [
-                                            "C1685/98"
-                                        ]
-                                    }
-                                },
-                                {
-                                    "label": {
-                                        "en": [
-                                            "Title"
-                                        ]
-                                    },
-                                    "value": {
-                                        "en": [
-                                            "Song of dreams"
-                                        ]
-                                    }
-                                },
-                                {
-                                    "label": {
-                                        "en": [
-                                            "Contributor"
-                                        ]
-                                    },
-                                    "value": {
-                                        "en": [
-                                            "Taylor, Becky (singer, female)",
-                                            "unidentified orchestra"
-                                        ]
-                                    }
-                                },
-                                {
-                                    "label": {
-                                        "en": [
-                                            "Date"
-                                        ]
-                                    },
-                                    "value": {
-                                        "en": [
-                                            "not after 1999-07-17"
-                                        ]
-                                    }
-                                }
-                            ],
-                            "type": "Range"
+                            ]
                         }
-                    ],
-                    "metadata": [
-                        {
-                            "label": {
-                                "en": [
-                                    "Identifier"
-                                ]
-                            },
-                            "value": {
-                                "en": [
-                                    "C1685/98"
-                                ]
-                            }
-                        },
-                        {
-                            "label": {
-                                "en": [
-                                    "Title"
-                                ]
-                            },
-                            "value": {
-                                "en": [
-                                    "Loose ends"
-                                ]
-                            }
-                        },
-                        {
-                            "label": {
-                                "en": [
-                                    "Place"
-                                ]
-                            },
-                            "value": {
-                                "en": [
-                                    "Royal Albert Hall, London"
-                                ]
-                            }
-                        },
-                        {
-                            "label": {
-                                "en": [
-                                    "Contributor"
-                                ]
-                            },
-                            "value": {
-                                "en": [
-                                    "Sherrin, Ned, 1931-2007 (speaker, male; presenter / interviewer)",
-                                    "Glover, Julian, 1935- (speaker, male; interviewee)",
-                                    "Windsor, Barbara, 1937- (speaker, female; interviewee)",
-                                    "The Proclaimers (speakers, male; interviewees / performers)",
-                                    "Frisby, Dominic (speaker, male)",
-                                    "Jupitus, Phil (speaker, male / interviewee)",
-                                    "Taylor, Becky (speaker, female; interviewee / singer)",
-                                    "Brown, Errol (speaker, male; interviewee)"
-                                ]
-                            }
-                        },
-                        {
-                            "label": {
-                                "en": [
-                                    "Date"
-                                ]
-                            },
-                            "value": {
-                                "en": [
-                                    "not after 1999-07-17"
-                                ]
-                            }
-                        }
-                    ],
-                    "type": "Range"
+                    ]
                 },
                 {
                     "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100052359795.0x00000c",
-                    "label": {
-                        "en": [
-                            "[News May 2001]"
-                        ]
-                    },
+                    "type": "Range",
+                    "label": { "en": [ "[News May 2001]" ] },
                     "members": [
                         {
                             "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100052359795.0x000004#t=2504.64,2661.56",
                             "type": "Canvas"
                         }
-                    ],
-                    "metadata": [
-                        {
-                            "label": {
-                                "en": [
-                                    "Identifier"
-                                ]
-                            },
-                            "value": {
-                                "en": [
-                                    "C1685/98"
-                                ]
-                            }
-                        },
-                        {
-                            "label": {
-                                "en": [
-                                    "Title"
-                                ]
-                            },
-                            "value": {
-                                "en": [
-                                    "[News May 2001]"
-                                ]
-                            }
-                        },
-                        {
-                            "label": {
-                                "en": [
-                                    "Contributor"
-                                ]
-                            },
-                            "value": {
-                                "en": [
-                                    "unidentified speaker, female (newsreader)"
-                                ]
-                            }
-                        },
-                        {
-                            "label": {
-                                "en": [
-                                    "Date"
-                                ]
-                            },
-                            "value": {
-                                "en": [
-                                    "not after 2001-05-19"
-                                ]
-                            }
-                        }
-                    ],
-                    "type": "Range"
+                    ]
                 },
                 {
                     "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100052359795.0x00000e",
-                    "label": {
-                        "en": [
-                            "Saturday review"
-                        ]
-                    },
+                    "type": "Range",
+                    "label": { "en": [ "Saturday review" ] },
                     "members": [
                         {
                             "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100052359795.0x000004#t=2661.56,3723.4",
@@ -396,261 +154,42 @@
                             "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100052359795.0x000005#t=0,1585.16",
                             "type": "Canvas"
                         }
-                    ],
-                    "metadata": [
-                        {
-                            "label": {
-                                "en": [
-                                    "Identifier"
-                                ]
-                            },
-                            "value": {
-                                "en": [
-                                    "C1685/98"
-                                ]
-                            }
-                        },
-                        {
-                            "label": {
-                                "en": [
-                                    "Title"
-                                ]
-                            },
-                            "value": {
-                                "en": [
-                                    "Saturday review"
-                                ]
-                            }
-                        },
-                        {
-                            "label": {
-                                "en": [
-                                    "Contributor"
-                                ]
-                            },
-                            "value": {
-                                "en": [
-                                    "Sutcliffe, Thomas, 1956- (speaker, male; presenter)",
-                                    "Roberts, Michèle, 1949- (speaker, female)",
-                                    "White, Jim, speaker (speaker, male)",
-                                    "Whittam Smith, Andreas, 1937- (speaker, male)"
-                                ]
-                            }
-                        },
-                        {
-                            "label": {
-                                "en": [
-                                    "Date"
-                                ]
-                            },
-                            "value": {
-                                "en": [
-                                    "not after 2001-05-19"
-                                ]
-                            }
-                        }
-                    ],
-                    "type": "Range"
+                    ]
                 },
                 {
                     "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100052359795.0x000011",
-                    "label": {
-                        "en": [
-                            "My dear Jim - Letters to a friend [2]"
-                        ]
-                    },
+                    "type": "Range",
+                    "label": { "en": [ "My dear Jim - Letters to a friend [2]" ] },
                     "members": [
                         {
                             "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100052359795.0x000005#t=1585.16,2501.8",
                             "type": "Canvas"
                         }
-                    ],
-                    "metadata": [
-                        {
-                            "label": {
-                                "en": [
-                                    "Identifier"
-                                ]
-                            },
-                            "value": {
-                                "en": [
-                                    "C1685/98"
-                                ]
-                            }
-                        },
-                        {
-                            "label": {
-                                "en": [
-                                    "Title"
-                                ]
-                            },
-                            "value": {
-                                "en": [
-                                    "My dear Jim - Letters to a friend [2]"
-                                ]
-                            }
-                        },
-                        {
-                            "label": {
-                                "en": [
-                                    "Contributor"
-                                ]
-                            },
-                            "value": {
-                                "en": [
-                                    "Rietti, Robert, 1923-2015 (speaker, male)"
-                                ]
-                            }
-                        },
-                        {
-                            "label": {
-                                "en": [
-                                    "Date"
-                                ]
-                            },
-                            "value": {
-                                "en": [
-                                    "not after 2001-05-19"
-                                ]
-                            }
-                        }
-                    ],
-                    "type": "Range"
+                    ]
                 },
                 {
                     "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100052359795.0x000013",
-                    "label": {
-                        "en": [
-                            "[News May 2001]"
-                        ]
-                    },
+                    "type": "Range",
+                    "label": { "en": [ "[News May 2001]" ] },
                     "members": [
                         {
                             "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100052359795.0x000005#t=2501.8,2620.44",
                             "type": "Canvas"
                         }
-                    ],
-                    "metadata": [
-                        {
-                            "label": {
-                                "en": [
-                                    "Identifier"
-                                ]
-                            },
-                            "value": {
-                                "en": [
-                                    "C1685/98"
-                                ]
-                            }
-                        },
-                        {
-                            "label": {
-                                "en": [
-                                    "Title"
-                                ]
-                            },
-                            "value": {
-                                "en": [
-                                    "[News May 2001]"
-                                ]
-                            }
-                        },
-                        {
-                            "label": {
-                                "en": [
-                                    "Contributor"
-                                ]
-                            },
-                            "value": {
-                                "en": [
-                                    "unidentified speaker, female (newsreader)"
-                                ]
-                            }
-                        },
-                        {
-                            "label": {
-                                "en": [
-                                    "Date"
-                                ]
-                            },
-                            "value": {
-                                "en": [
-                                    "not after 1999-05-19"
-                                ]
-                            }
-                        }
-                    ],
-                    "type": "Range"
+                    ]
                 },
                 {
                     "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100052359795.0x000015",
-                    "label": {
-                        "en": [
-                            "The archive hour: Humph at 80"
-                        ]
-                    },
+                    "type": "Range",
+                    "label": { "en": [ "The archive hour: Humph at 80" ] },
                     "members": [
                         {
                             "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100052359795.0x000005#t=2620.44,3723.4",
                             "type": "Canvas"
                         }
-                    ],
-                    "metadata": [
-                        {
-                            "label": {
-                                "en": [
-                                    "Identifier"
-                                ]
-                            },
-                            "value": {
-                                "en": [
-                                    "C1685/98"
-                                ]
-                            }
-                        },
-                        {
-                            "label": {
-                                "en": [
-                                    "Title"
-                                ]
-                            },
-                            "value": {
-                                "en": [
-                                    "The archive hour: Humph at 80"
-                                ]
-                            }
-                        },
-                        {
-                            "label": {
-                                "en": [
-                                    "Contributor"
-                                ]
-                            },
-                            "value": {
-                                "en": [
-                                    "Lyttelton, Humphrey, 1921-2008 (speaker, male; presenter)",
-                                    "unidentified speakers"
-                                ]
-                            }
-                        },
-                        {
-                            "label": {
-                                "en": [
-                                    "Date"
-                                ]
-                            },
-                            "value": {
-                                "en": [
-                                    "not after 2001-05-19"
-                                ]
-                            }
-                        }
-                    ],
-                    "type": "Range"
+                    ]
                 }
-            ],
-            "type": "Range"
+            ]
         }
-    ],
-    "type": "Manifest"
+    ]
 }

--- a/examples/data/bl/sounds-tests/collection.json
+++ b/examples/data/bl/sounds-tests/collection.json
@@ -1,0 +1,61 @@
+{
+    "@context": [
+      "http://www.w3.org/ns/anno.jsonld",
+      "http://iiif.io/api/presentation/3/context.json"
+    ],
+    "id": "https://iiif-commons.github.io/iiif-av-component/examples/data/bl/sounds-tests/collection.json",
+    "type": "Collection",
+    "label": { "en": ["BL Sounds tests" ] },  
+    "items": [
+        {
+            "id": "https://iiif-commons.github.io/iiif-av-component/examples/data/bl/sounds-tests/C308_8.json",
+            "type": "Manifest",
+            "label": { "en": [ "C308/8 Brian Hayes programme" ] }
+        },
+        {
+            "id": "https://iiif-commons.github.io/iiif-av-component/examples/data/bl/sounds-tests/C465_13.json",
+            "type": "Manifest",
+            "label": { "en": [ "C465/13/01-14 Jocelyn Herbert interviewed by Cathy Courtney" ] }
+        },
+        {
+            "id": "https://iiif-commons.github.io/iiif-av-component/examples/data/bl/sounds-tests/C728_241.json",
+            "type": "Manifest",
+            "label": { "en": [ "C728/241 [Demo]" ] }
+        },
+        {
+            "id": "https://iiif-commons.github.io/iiif-av-component/examples/data/bl/sounds-tests/C733_48.json",
+            "type": "Manifest",
+            "label": { "en": [ "C733/48 C733/49 C733/50 [Recordings in Soqotri / 'Survey' recordings in English]" ] }
+        },
+        {
+            "id": "https://iiif-commons.github.io/iiif-av-component/examples/data/bl/sounds-tests/C1074_6.json",
+            "type": "Manifest",
+            "label": { "en": [ "C1074/6 Igbo Iwin overlays" ] }
+        },
+        {
+            "id": "https://iiif-commons.github.io/iiif-av-component/examples/data/bl/sounds-tests/C1132_116.json",
+            "type": "Manifest",
+            "label": { "en": [ "C1132/116 Cliff Richard (Heathcliff)" ] }
+        },
+        {
+            "id": "https://iiif-commons.github.io/iiif-av-component/examples/data/bl/sounds-tests/C1685_98.json",
+            "type": "Manifest",
+            "label": { "en": [ "C1685/98 Loose ends 17/7/99" ] }
+        },
+        {
+            "id": "https://iiif-commons.github.io/iiif-av-component/examples/data/bl/sounds-tests/DA.json",
+            "type": "Manifest",
+            "label": { "en": [ "The Winter Hymn (Ambient Version)" ] }
+        },
+        {
+            "id": "https://iiif-commons.github.io/iiif-av-component/examples/data/bl/sounds-tests/WS0003.json",
+            "type": "Manifest",
+            "label": { "en": [ "WS0003" ] }
+        },
+        {
+            "id": "https://iiif-commons.github.io/iiif-av-component/examples/data/bl/sounds-tests/C308_8.json",
+            "type": "Manifest",
+            "label": { "en": [ "WS0003 Aburria aburri r1" ] }
+        }
+    ]  
+  }

--- a/examples/data/bl/sounds-tests/index.html
+++ b/examples/data/bl/sounds-tests/index.html
@@ -4,23 +4,88 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
-    <title>Document</title>
+    <title>BL Sounds Tests</title>
     <style>
         body {
             font-family: sans-serif;
+        }
+        ul.manifests > li {
+            font-weight: bold;
+            margin-bottom: 1em;
+        }
+        ul.range li {
+            font-weight:300;
         }
         </style>
 </head>
 <body>
     <h1>AV test manifests</h1>
+    
+    <ul id="theList" class="manifests"></ul>
 
-    <ul>
-            <li><a href="https://universalviewer.io/examples/uv/uv.html#?manifest=https://iiif-commons.github.io/iiif-av-component/examples/data/bl/sounds-tests/C308_8.json"><b>C308_8</b> <i>Brian Hayes programme</i></a></li>
-            <li><a href="https://universalviewer.io/examples/uv/uv.html#?manifest=https://iiif-commons.github.io/iiif-av-component/examples/data/bl/sounds-tests/C728_241.json"><b>C728_241</b> <i>[Demo]</i></a></li>
-            <li><a href="https://universalviewer.io/examples/uv/uv.html#?manifest=https://iiif-commons.github.io/iiif-av-component/examples/data/bl/sounds-tests/C1132_116.json"><b>C1132_116</b> <i>Cliff Richard interview (Heathcliff)</i></a></li>
-            <li><a href="https://universalviewer.io/examples/uv/uv.html#?manifest=https://iiif-commons.github.io/iiif-av-component/examples/data/bl/sounds-tests/C1685_98.json"><b>C1685_98</b> <i>Loose ends 17/7/99</i></a></li>
-            <li><a href="https://universalviewer.io/examples/uv/uv.html#?manifest=https://iiif-commons.github.io/iiif-av-component/examples/data/bl/sounds-tests/WS0003.json"><b>WS0003</b> <i>Aburria aburri r1</i></a></li>
-    </ul>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+    <script>
+
+        function makeUrl(manifestId, rangeId){
+            var s = "http://universalviewer.io/examples/template.html#?manifest=" + manifestId;
+            if(rangeId){
+                s += "&rid=" + rangeId;
+            }
+            return s;
+        }
+
+        function getString(langMap){
+            if(typeof langMap === 'string') return langMap; // not valid, but...
+            var anyValue = null;
+            for(lang in langMap){
+                anyValue = langMap[lang][0];
+                break;
+            }
+            return anyValue;
+        }
+
+        function loadRanges(manifestId, listId){
+            $.getJSON(manifestId, function(manifest){
+                processItems(manifestId, manifest.structures, $("#" + listId), "r_");
+            });
+        }
+
+        function processItems(manifestId, items, $element, prefix){
+            var $list = null;
+            for(var i=0; i<items.length; i++){
+                var range = items[i];
+                if(range.type == "Range"){
+                    var label = getString(range.label);
+                    if(label && "hidden" != range.behavior){
+                        if(!$list){
+                            $list = $("<ul class='range'></ul>").appendTo($element);
+                        }
+                        elementId = prefix + "_" + i;
+                        var $listItem = appendListItemLink($list, elementId, makeUrl(manifestId, range.id), getString(range.label))
+                        children = range.items || range.members; // yes, in flux...
+                        if(children){
+                            processItems(manifestId, children, $listItem, elementId);
+                        }     
+                    }
+                }
+            }
+        }
+
+        function appendListItemLink($element, liId, linkUrl, text){
+            var html = '<li id="' + liId + '"><a href="' + linkUrl + '">' + text + '</a></li>';
+            return $(html).appendTo($element);
+        }
+
+        $(function() {
+            $.getJSON( "collection.json", function( collection ) {
+                $.each( collection.items, function( index, manifest ) {
+                    appendListItemLink($('#theList'), "li" + index, makeUrl(manifest.id), getString(manifest.label))
+                    loadRanges(manifest.id, 'li' + index);
+                });
+            });
+        });
+    </script>
+
     
 </body>
 </html>


### PR DESCRIPTION
This should be structurally identical to the existing Loose Ends (C1685_98), but with prettified and re-ordered JSON for ease of reading. Range-level metadata has been removed.