### PR TITLE
Added MediaError handling

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -427,6 +427,30 @@
           $ppc.removeAttr("disabled");
         });
 
+        avcomponent.on("mediaerror", function(error) {
+          $(".player").removeClass("player--loading");
+          var errormessage = "Error: ";
+          switch (error.code) {
+            case 1:
+              errormessage += "loading aborted";
+            break;
+            case 2: 
+              errormessage += "network error";
+            break;
+            case 3:
+              errormessage += "decoding of media failed";
+            break;
+            case 4:
+                errormessage += "media format not suppported by this browser";
+            break;
+            default: 
+              errormessage += "unknown";
+            break;
+          }
+
+          $(".canvas-container").append("<div class='anno errormessage'>"+errormessage+"</div>")
+        });
+
         $ppc.on("click", function(e) {
           e.preventDefault();
           if (avcomponent._isPlaying) {

--- a/examples/styles.css
+++ b/examples/styles.css
@@ -162,4 +162,12 @@ overflow: hidden;
 .iiif-tree-component ul li a.selected {
 color: green !important;
 }
+
+.errormessage {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: 100%;
+    height: 100%;
+  }
   

--- a/src/AVComponent.ts
+++ b/src/AVComponent.ts
@@ -1028,6 +1028,10 @@ namespace IIIFComponents {
 
             const media: HTMLMediaElement = $mediaElement[0] as HTMLMediaElement;
 
+            media.onerror = () => {
+                this.fire(AVComponent.Events.MEDIA_ERROR, media.error);
+            }
+
             if (data.format && data.format.toString() === 'application/dash+xml') {
                 // dash
                 $mediaElement.attr('data-dashjs-player', '');
@@ -2667,6 +2671,11 @@ namespace IIIFComponents {
                 this._setCanvasInstanceVolumes(volume);
                 this.fire(VolumeEvents.VOLUME_CHANGED, volume);
             }, false);
+
+            canvasInstance.on(AVComponent.Events.MEDIA_ERROR, (error : MediaError) => {
+                clearInterval(this._checkAllMediaReadyInterval);
+                this.fire(AVComponent.Events.MEDIA_ERROR, error);
+            }, false);
         }
 
         public getCurrentRange(): Manifesto.IRange | null {
@@ -2927,6 +2936,7 @@ namespace IIIFComponents.AVComponent {
         static PLAY: string = 'play';
         static PAUSE: string = 'pause';
         static MEDIA_READY: string = 'mediaready';
+        static MEDIA_ERROR: string = 'mediaerror';
         static LOG: string = 'log';
         static RANGE_CHANGED: string = 'rangechanged';
         static WAVEFORM_READY: string = 'waveformready';


### PR DESCRIPTION
Not all media is always available or playable by a browser, in this case the MediaError event is being thrown on the avcomponent so that it can be handled.

For an example see examples/index.html

![unsupported_media](https://user-images.githubusercontent.com/5212876/63441133-3c8fa800-c431-11e9-93b2-79ea4c5a469c.png)

For more details about MediaErrror see https://developer.mozilla.org/en-US/docs/Web/API/MediaError