### PR TITLE
Fix Hls support

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -8,6 +8,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.2.3/jquery.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jsviews/0.9.76/jsviews.min.js"></script>
     <!-- <script src="https://unpkg.com/proxy-observe@0.0.21/browser/proxy-observe.min.js"></script> -->
+    <script src="https://cdn.jsdelivr.net/npm/hls.js@1"></script>
     <script src="https://unpkg.com/@iiif/iiif-tree-component/dist-umd/IIIFTreeComponent.js"></script>
     <script src="https://unpkg.com/manifesto.js/dist-umd/manifesto.js"></script>
     <script src="https://unpkg.com/@iiif/manifold/dist-umd/manifold.js"></script>

--- a/src/helpers/can-play-hls.ts
+++ b/src/helpers/can-play-hls.ts
@@ -1,20 +1,6 @@
-import { hlsMimeTypes } from './hls-media-types';
 import { getHls } from './get-hls';
 
 export function canPlayHls() {
   const Hls = getHls();
-  const doc = typeof document === 'object' && document;
-  const videoElement = doc && doc.createElement('video');
-  const isVideoSupported = Boolean(videoElement && videoElement.canPlayType);
-
-  return (
-    Hls &&
-    isVideoSupported &&
-    hlsMimeTypes.some((canItPlay: string) => {
-      if (videoElement) {
-        return /maybe|probably/i.test(videoElement.canPlayType(canItPlay));
-      }
-      return false;
-    })
-  );
+  return Hls && Hls.isSupported();
 }


### PR DESCRIPTION
The previous `canPlayHls` implementation did not work. This uses the `Hls.isSupported` method instead.
Consuming code will have to add required [hls.js dependency](https://www.npmjs.com/package/hls.js).

Closes #30 